### PR TITLE
Add WebSocket provider and events Eth & Nervos tests.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,9 +1,5 @@
-name: Build and deploy frontend
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+name: Test & Build & Deploy
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,10 +13,13 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn
+    - run: yarn start-eth-node > /dev/null 2>&1 &
     - run: yarn compile
-    - run: yarn build
+    - run: yarn test:eth
     - run: yarn test
+    - run: yarn build
     - name: Deploy to Skynet
+      if: github.ref == 'refs/heads/master'
       uses: SkynetLabs/deploy-to-skynet-action@v2
       with:
         upload-dir: build

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -5,12 +5,15 @@ pragma solidity >=0.8.0;
 contract SimpleStorage {
     uint256 storedData;
 
+    event ValueChanged(address indexed _from, uint256 _value);
+
     constructor() payable {
         storedData = 123;
     }
 
     function set(uint256 x) public payable {
         storedData = x;
+        emit ValueChanged(msg.sender, x);
     }
 
     function get() public view returns (uint256) {

--- a/hardhat.config.eth.js
+++ b/hardhat.config.eth.js
@@ -1,0 +1,9 @@
+require('@nomiclabs/hardhat-web3');
+
+module.exports = {
+    solidity: '0.8.4',
+    paths: {
+        artifacts: "./src/artifacts",
+        tests: "./test-eth"
+    }
+};

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
         "start": "react-app-rewired start",
         "build": "react-app-rewired build",
         "test": "hardhat test",
+        "test:eth": "hardhat test --config hardhat.config.eth.js",
         "eject": "react-scripts eject",
         "compile": "hardhat compile",
         "deploy": "node scripts/deploy.mjs",
-        "prettier": "prettier --write --config-precedence file-override './src/**/*'"
+        "prettier": "prettier --write --config-precedence file-override './src/**/*'",
+        "start-eth-node": "hardhat node"
     },
     "eslintConfig": {
         "extends": [
@@ -44,7 +46,8 @@
         "react-scripts": "4.0.3",
         "react-toastify": "^8.0.2",
         "web-vitals": "^1.0.1",
-        "web3": "1.5.2"
+        "web3": "1.5.2",
+        "web3-providers-ws": "^1.5.3"
     },
     "devDependencies": {
         "@babel/plugin-syntax-bigint": "^7.8.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,8 @@
 import { useEffect, useState, useRef } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
 import { AddressTranslator } from 'nervos-godwoken-integration';
-import Web3 from 'web3';
-import { PolyjuiceHttpProvider } from '@polyjuice-provider/web3';
 
-import CONFIG from './config';
+import { web3 } from './config.testnet';
 import SimpleStorageJSON from './artifacts/contracts/SimpleStorage.sol/SimpleStorage.json';
 
 import './App.css';
@@ -13,13 +11,6 @@ import 'react-toastify/dist/ReactToastify.css';
 async function createWeb3() {
   // Modern dapp browsers...
   if (window.ethereum) {
-      const providerConfig = {
-          web3Url: CONFIG.HTTP_RPC_URL
-      };
-
-      const provider = new PolyjuiceHttpProvider(CONFIG.HTTP_RPC_URL, providerConfig);
-      const web3 = new Web3(provider || Web3.givenProvider);
-
       try {
           // Request account access if needed
           await window.ethereum.enable();

--- a/src/config.eth.js
+++ b/src/config.eth.js
@@ -1,0 +1,20 @@
+const Web3 = require('web3');
+const WebsocketProvider = require('web3-providers-ws');
+
+const CONFIG = {
+    WS_RPC_URL: 'ws://127.0.0.1:8545',
+    USER_ONE_PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+}
+
+const provider = new WebsocketProvider(CONFIG.WS_RPC_URL);
+
+const web3 = new Web3(provider);
+
+const userOne = web3.eth.accounts.wallet.add(CONFIG.USER_ONE_PRIVATE_KEY);
+
+module.exports = {
+    ...CONFIG,
+    provider,
+    web3,
+    userOne
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,0 @@
-module.exports = {
-    HTTP_RPC_URL: 'https://godwoken-testnet-web3-rpc.ckbapp.dev',
-    USER_ONE_PRIVATE_KEY: '0xd9066ff9f753a1898709b568119055660a77d9aae4d7a4ad677b8fb3d2a571e5'
-};

--- a/src/config.testnet.js
+++ b/src/config.testnet.js
@@ -1,0 +1,29 @@
+const Web3 = require('web3');
+const { PolyjuiceAccounts, PolyjuiceWebsocketProvider } = require('@polyjuice-provider/web3');
+
+const CONFIG = {
+    HTTP_RPC_URL: 'https://godwoken-testnet-web3-rpc.ckbapp.dev',
+    WS_RPC_URL: 'ws://godwoken-testnet-web3-rpc.ckbapp.dev/ws',
+    USER_ONE_PRIVATE_KEY: '0xd9066ff9f753a1898709b568119055660a77d9aae4d7a4ad677b8fb3d2a571e5'
+}
+
+const providerConfig = {
+    web3Url: CONFIG.HTTP_RPC_URL
+};
+
+const provider = new PolyjuiceWebsocketProvider(CONFIG.WS_RPC_URL, providerConfig);
+    
+const polyjuiceAccounts = new PolyjuiceAccounts(providerConfig);
+
+const web3 = new Web3(provider);
+web3.eth.accounts = polyjuiceAccounts;
+web3.eth.Contract.setProvider(provider, web3.eth.accounts);
+
+const userOne = web3.eth.accounts.wallet.add(CONFIG.USER_ONE_PRIVATE_KEY);
+
+module.exports = {
+    ...CONFIG,
+    provider,
+    web3,
+    userOne
+};

--- a/test-eth/SimpleStorage.eth.js
+++ b/test-eth/SimpleStorage.eth.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { readFile } = require('fs/promises');
-const { web3, userOne } = require('../src/config.testnet');
+const { web3, userOne } = require('../src/config.eth');
 
 describe('SimpleStorage', function () {
     let contract;

--- a/test/SimpleStorage.js
+++ b/test/SimpleStorage.js
@@ -45,15 +45,15 @@ describe('SimpleStorage', function () {
                 expect(error).to.equal(null);
                 expect(event.event).to.equal('ValueChanged');
                 expect(event.removed).to.equal(false);
-                expect(event.logIndex).to.equal(0);
-                expect(event.transactionIndex).to.equal(0);
+                expect(event.logIndex >= 0).to.equal(true);
+                expect(event.transactionIndex >= 0).to.equal(true);
                 expect(typeof event.returnValues).to.equal('object');
                 expect(typeof event.raw).to.equal('object');
 
                 resolve();
             });
         });
-    });
+    }).timeout(200000);
 
     it(`ValueChanged events can be captured via contract.events.ValueChanged`, async function () {
         await new Promise(resolve => {
@@ -63,15 +63,15 @@ describe('SimpleStorage', function () {
                 expect(error).to.equal(null);
                 expect(event.event).to.equal('ValueChanged');
                 expect(event.removed).to.equal(false);
-                expect(event.logIndex).to.equal(0);
-                expect(event.transactionIndex).to.equal(0);
+                expect(event.logIndex >= 0).to.equal(true);
+                expect(event.transactionIndex >= 0).to.equal(true);
                 expect(typeof event.returnValues).to.equal('object');
                 expect(typeof event.raw).to.equal('object');
 
                 resolve();
             });
         });
-    });
+    }).timeout(200000);
 
     it(`ValueChanged events can be captured via contract.getPastEvents`, async function () {
         const events = await contract.getPastEvents('ValueChanged', {
@@ -85,9 +85,9 @@ describe('SimpleStorage', function () {
 
         expect(event.event).to.equal('ValueChanged');
         expect(event.removed).to.equal(false);
-        expect(event.logIndex).to.equal(0);
-        expect(event.transactionIndex).to.equal(0);
+        expect(event.logIndex >= 0).to.equal(true);
+        expect(event.transactionIndex >= 0).to.equal(true);
         expect(typeof event.returnValues).to.equal('object');
         expect(typeof event.raw).to.equal('object');
-    });
+    }).timeout(200000);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14340,6 +14340,14 @@ web3-core-helpers@1.5.2:
     web3-eth-iban "1.5.2"
     web3-utils "1.5.2"
 
+web3-core-helpers@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.5.3.tgz#099030235c477aadf39a94199ef40092151d563c"
+  integrity sha512-Ip1IjB3S8vN7Kf1PPjK41U5gskmMk6IJQlxIVuS8/1U7n/o0jC8krqtpRwiMfAgYyw3TXwBFtxSRTvJtnLyXZw==
+  dependencies:
+    web3-eth-iban "1.5.3"
+    web3-utils "1.5.3"
+
 web3-core-method@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.5.2.tgz#d1d602657be1000a29d11e3ca3bf7bc778dea9a5"
@@ -14452,6 +14460,14 @@ web3-eth-iban@1.5.2:
     bn.js "^4.11.9"
     web3-utils "1.5.2"
 
+web3-eth-iban@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.5.3.tgz#91b1475893a877b10eac1de5cce6eb379fb81b5d"
+  integrity sha512-vMzmGqolYZvRHwP9P4Nf6G8uYM5aTLlQu2a34vz78p0KlDC+eV1th3+90Qeaupa28EG7OO0IT1F0BejiIauOPw==
+  dependencies:
+    bn.js "^4.11.9"
+    web3-utils "1.5.3"
+
 web3-eth-personal@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.5.2.tgz#043335a19ab59e119ba61e3bd6c3b8cde8120490"
@@ -14516,6 +14532,15 @@ web3-providers-ws@1.5.2, web3-providers-ws@^1.5.2:
     web3-core-helpers "1.5.2"
     websocket "^1.0.32"
 
+web3-providers-ws@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.5.3.tgz#eec6cfb32bb928a4106de506f13a49070a21eabf"
+  integrity sha512-6DhTw4Q7nm5CFYEUHOJM0gAb3xFx+9gWpVveg3YxJ/ybR1BUvEWo3bLgIJJtX56cYX0WyY6DS35a7f0LOI1kVg==
+  dependencies:
+    eventemitter3 "4.0.4"
+    web3-core-helpers "1.5.3"
+    websocket "^1.0.32"
+
 web3-shh@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.5.2.tgz#a72a3d903c0708a004db94a72d934a302d880aea"
@@ -14530,6 +14555,19 @@ web3-utils@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.5.2.tgz#150982dcb1918ffc54eba87528e28f009ebc03aa"
   integrity sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==
+  dependencies:
+    bn.js "^4.11.9"
+    eth-lib "0.2.8"
+    ethereum-bloom-filters "^1.0.6"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
+web3-utils@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.5.3.tgz#e914c9320cd663b2a09a5cb920ede574043eb437"
+  integrity sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==
   dependencies:
     bn.js "^4.11.9"
     eth-lib "0.2.8"


### PR DESCRIPTION
Currently Nervos workflow is broken due to not being able to capture event using web3.js + polyjuice websocket provider on Nervos Layer 2 testnet.

There are 2 test commands ran on CI:
1. `yarn test:eth` - which is using local hardhat node, it succeeds and correctly captures events.
2. `yarn test` - which is using Nervos testnet, it fails and can't capture events.